### PR TITLE
Fix template issues

### DIFF
--- a/playbooks/templates/engine_yaml.j2
+++ b/playbooks/templates/engine_yaml.j2
@@ -13,7 +13,7 @@
   {% endif %}
     smc_logging:
         level: 10
-        path: /Users/davidlepage/Downloads/ansible-smc.log
+        path: ansible-smc.log
 {% for engine in results.ansible_facts.engines %}
 {{- engine | to_nice_yaml | indent(6, True) }}
 {% endfor %}

--- a/playbooks/templates/engine_yaml.j2
+++ b/playbooks/templates/engine_yaml.j2
@@ -6,8 +6,10 @@
   - name: Create a single layer 3 firewall
   {% if 'single_fw' in results.engine_type %}
   engine:
+      type: single_fw
   {% elif 'cluster' in results.engine_type %}
   engine:
+      type: cluster
   {% endif %}
     smc_logging:
         level: 10


### PR DESCRIPTION
It looks like there are 2 issues with the engine_facts template:
 - the single and cluster clauses dont actually specify the firewall type
 - there is a hardcoded path for the log file
