### PR TITLE
Make this git repolsitory usable with ansible-galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,60 @@
+galaxy_info:
+  role_name: ansible-stonesoft
+  author: Sébastien Boulet
+  description: Creates some network-elements on Forcepoint SMC
+  company: Newlode Group / Optalia
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 1.2
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags:
+    ["SMC", "Forcepoint"]
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies:
+  []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,21 +1,14 @@
 galaxy_info:
   role_name: ansible-stonesoft
-  author: Sébastien Boulet
-  description: Creates some network-elements on Forcepoint SMC
-  company: Newlode Group / Optalia
+  author: David LePage
+  description: This repository provides Ansible modules for configuration and automation of Stonesoft Next Generation Firewall. It uses the smc-python for all operations between the ansible client and the Stonesoft Management Center.
+  company: Forcepoint
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
+  issue_tracker_url: https://github.com/gabstopper/ansible-stonesoft/issues
 
-  # Some suggested licenses:
-  # - BSD (default)
-  # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
-  license: license (GPLv2, CC-BY, etc)
+  license: Apache License 2.0
 
   min_ansible_version: 1.2
 
@@ -46,7 +39,7 @@ galaxy_info:
   #   - 99.99
 
   galaxy_tags:
-    ["SMC", "Forcepoint"]
+    ["smc", "forcepoint", "stonesoft", "networking", "security", "ngfw"]
     # List tags for your role here, one per line. A tag is a keyword that describes
     # and categorizes the role. Users find roles by searching for tags. Be sure to
     # remove the '[]' above, if you add tags to this list.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+# install required libraries
+- pip:
+    name: smc-python


### PR DESCRIPTION
Hi David,

According to [Ansible documentation](https://galaxy.ansible.com/docs/contributing/creating_role.html), `meta/main.yml` need to declare some generic informations.

I made a first version of this file to be able to do this:
```bash
» ansible-galaxy install -p roles/ git+https://github.com/sebbbastien/ansible-stonesoft.git,develop
- extracting ansible-stonesoft to /home/seb/roles/ansible-stonesoft
- ansible-stonesoft (develop) was installed successfully
``` 

It can also be done with a requirement file:
```bash
» cat ansible-requirements.yml
- src: git+https://github.com/sebbbastien/ansible-stonesoft.git
  version: develop
» ansible-galaxy install -p roles/ -r requirements.yml
- extracting ansible-stonesoft to /home/seb/roles/ansible-stonesoft
- ansible-stonesoft (develop) was installed successfully
```

Hope it will help you,

Best regards,